### PR TITLE
typo

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -21,7 +21,7 @@ function loadFileAsURL(){
 		imageMsg.textContent = 'This is the content of file: ' + fileToLoad.name
 	}else{
 		fileReader.readAsDataURL(fileToLoad, "UTF-8");
-		imageMsg.textContent = 'File ' + fielToLoad.name + ' has been loaded in encoded form'
+		imageMsg.textContent = 'File ' + fileToLoad.name + ' has been loaded in encoded form'
 	}
 }
 


### PR DESCRIPTION
```javascript
imageMsg.textContent = 'File ' + fielToLoad.name + ' has been loaded in encoded form'
```
Corrected the typo because it causes this error:

```javascript
main.js:24 Uncaught ReferenceError: fielToLoad is not defined
    at HTMLInputElement.loadFileAsURL
```